### PR TITLE
Add support for custom type serialization to 1.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 script:
   - bundle exec rake test
 rvm:
-  - 1.9.3
+  - 2.3.0
+  - 2.2
+  - 2.1
   - 2.0.0
-  - 2.1.2
+  - ruby-head

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -269,9 +269,14 @@ void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, int trusted)
 		return;
 
 	default:
-		rb_raise(rb_eMochiloPackError,
-				"Unsupported object type: %s", rb_obj_classname(rb_object));
+		if (rb_respond_to(rb_object, rb_intern("to_bpack"))) {
+			VALUE bpack = rb_funcall(rb_object, rb_intern("to_bpack"), 0);
+
+			mochilo_buf_put(buf, RSTRING_PTR(bpack), RSTRING_LEN(bpack));
+		} else {
+			rb_raise(rb_eMochiloPackError,
+					"Unsupported object type: %s", rb_obj_classname(rb_object));
+		}
 		return;
 	}
 }
-

--- a/mochilo.gemspec
+++ b/mochilo.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.4.2}
   s.summary = %q{A ruby library for BananaPack}
-  s.test_files = `git ls-files spec`.split("\n")
+  s.test_files = `git ls-files test`.split("\n")
   s.required_ruby_version = ">= 1.9.3"
 
   # tests

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -165,11 +165,9 @@ class MochiloPackTest < MiniTest::Unit::TestCase
   end
 
   def test_pack_custom_type
-    val = "custom"
+    obj = CustomType.new("custom")
 
-    obj = CustomType.new(val)
-
-    assert_equal val, Mochilo.pack(obj)
+    assert_equal "\xA6custom", Mochilo.pack(obj)
   end
 
   def test_pack_unsupported_type

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -164,6 +164,14 @@ class MochiloPackTest < MiniTest::Unit::TestCase
     # TODO: not sure how to test this without making a massive 66k item hash
   end
 
+  def test_pack_custom_type
+    val = "custom"
+
+    obj = CustomType.new(val)
+
+    assert_equal val, Mochilo.pack(obj)
+  end
+
   def test_pack_unsupported_type
     assert_raises Mochilo::PackError do
       Mochilo.pack(Object.new)

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -14,3 +14,12 @@ require 'minitest/autorun'
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift File.expand_path('..', __FILE__)
 
+class CustomType
+  def initialize(str)
+    @str = str
+  end
+
+  def to_bpack
+    @str
+  end
+end

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -20,6 +20,6 @@ class CustomType
   end
 
   def to_bpack
-    @str
+    Mochilo.pack(@str)
   end
 end


### PR DESCRIPTION
(This was https://github.com/brianmario/mochilo/pull/12 but re-created to pull back into the correct base branch)

This allows the caller to pass objects which respond to `to_bpack`. This method should return a string, which will be appended to the buffer un-touched. This is similar to how `to_json` and `to_msgpack` work.

For example, the following would allow `Time` objects to be serialized as an integer in unixtime.

```ruby
class Time
  def to_bpack
    Mochilo.pack(self.to_i)
  end
end
```

/cc @jnunemaker