### PR TITLE
Move msgpack dep to benchmark group in Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 script:
   - bundle exec rake test
+install: ./script/bootstrap
 rvm:
   - 1.9.3
   - 2.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "pry"
+
+group :benchmark do
+  gem "msgpack"
+end

--- a/mochilo.gemspec
+++ b/mochilo.gemspec
@@ -20,6 +20,4 @@ Gem::Specification.new do |s|
   # tests
   s.add_development_dependency 'rake-compiler', ">= 0.8.1"
   s.add_development_dependency 'minitest', ">= 4.1.0"
-  # benchmarks
-  s.add_development_dependency 'msgpack'
 end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,5 +12,5 @@ cd "$(dirname "$0")/.."
 if bundle check 1>/dev/null 2>&1; then
     echo "Gem environment up-to-date"
 else
-    exec bundle install --binstubs --path vendor/gems "$@"
+    exec bundle install --binstubs --path vendor/gems --without benchmark "$@"
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -12,5 +12,6 @@ cd "$(dirname "$0")/.."
 if bundle check 1>/dev/null 2>&1; then
     echo "Gem environment up-to-date"
 else
+    gem update bundler
     exec bundle install --binstubs --path vendor/gems --without benchmark "$@"
 fi

--- a/test/setup.rb
+++ b/test/setup.rb
@@ -10,6 +10,10 @@ require 'bundler/setup'
 # bring in minitest
 require 'minitest/autorun'
 
+if !defined?(MiniTest::Test)
+  MiniTest::Test = MiniTest::Unit::TestCase
+end
+
 # put lib and test dirs directly on load path
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 $LOAD_PATH.unshift File.expand_path('..', __FILE__)


### PR DESCRIPTION
The msgpack gem isn't required for anything other than benchmarking so let's skip building it in all of our automated scripts.

Should fix the build errors we were seeing in https://github.com/brianmario/mochilo/pull/15.

cc @kivikakk