### PR TITLE
Let callers provide pack/unpack implementations for unsupported types

### DIFF
--- a/ext/mochilo/mochilo.h
+++ b/ext/mochilo/mochilo.h
@@ -151,7 +151,7 @@ enum msgpack_err_t {
 
 typedef void * mo_value;
 typedef uint64_t mo_integer;
-int mochilo_unpack_one(mo_value *_value, mochilo_src *src);
+int mochilo_unpack_one(mo_value *_value, mochilo_src *src, VALUE rb_opts);
 
 #include <ruby/encoding.h>
 #include "encodings.h"

--- a/ext/mochilo/mochilo.rb.c
+++ b/ext/mochilo/mochilo.rb.c
@@ -22,8 +22,9 @@ static VALUE rb_mMochilo;
 static VALUE rb_eMochiloError;
 VALUE rb_eMochiloPackError;
 VALUE rb_eMochiloUnpackError;
+ID s_call;
 
-extern void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object);
+extern void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, VALUE rb_opts);
 
 static VALUE rb_mochilo__unpack(VALUE rb_buffer)
 {
@@ -68,15 +69,19 @@ static VALUE rb_mochilo_unpack(VALUE self, VALUE rb_buffer)
  *
  * call-seq:
  *     Mochilo.pack(obj) -> String
+ *     Mochilo.pack(obj, custom_type_config) -> String
  *
  * Packs a Ruby object into BananaPack format.
  */
-static VALUE rb_mochilo_pack(VALUE self, VALUE rb_obj)
+static VALUE rb_mochilo_pack(int argc, VALUE *argv, VALUE self)
 {
+	VALUE rb_obj, rb_opts;
 	mochilo_buf buf;
 
+	rb_scan_args(argc, argv, "11", &rb_obj, &rb_opts);
+
 	mochilo_buf_init(&buf);
-	mochilo_pack_one(&buf, rb_obj);
+	mochilo_pack_one(&buf, rb_obj, rb_opts);
 	return mochilo_buf_flush(&buf);
 }
 
@@ -84,9 +89,11 @@ void Init_mochilo()
 {
 	rb_mMochilo = rb_define_module("Mochilo");
 	rb_define_method(rb_mMochilo, "unpack", rb_mochilo_unpack, 1);
-	rb_define_method(rb_mMochilo, "pack", rb_mochilo_pack, 1);
+	rb_define_method(rb_mMochilo, "pack", rb_mochilo_pack, -1);
 
 	rb_eMochiloError = rb_define_class_under(rb_mMochilo, "Error", rb_eStandardError);
 	rb_eMochiloPackError = rb_define_class_under(rb_mMochilo, "PackError", rb_eMochiloError);
 	rb_eMochiloUnpackError = rb_define_class_under(rb_mMochilo, "UnpackError", rb_eMochiloError);
+
+	s_call = rb_intern("call");
 }

--- a/ext/mochilo/mochilo.rb.c
+++ b/ext/mochilo/mochilo.rb.c
@@ -26,7 +26,7 @@ ID s_call;
 
 extern void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, VALUE rb_opts);
 
-static VALUE rb_mochilo__unpack(VALUE rb_buffer)
+static VALUE rb_mochilo__unpack(VALUE rb_buffer, VALUE rb_opts)
 {
 	VALUE rb_result;
 	int error = -1;
@@ -37,7 +37,7 @@ static VALUE rb_mochilo__unpack(VALUE rb_buffer)
 	source.ptr = RSTRING_PTR(rb_buffer);
 	source.end = source.ptr + RSTRING_LEN(rb_buffer);
 
-	error = mochilo_unpack_one((mo_value)&rb_result, &source);
+	error = mochilo_unpack_one((mo_value)&rb_result, &source, rb_opts);
 	if (error < 0) {
 		switch (error) {
 			case MSGPACK_EEOF:
@@ -57,12 +57,15 @@ static VALUE rb_mochilo__unpack(VALUE rb_buffer)
  *
  * call-seq:
  *     Mochilo.unpack(banana_pack_str) -> Object
+ *     Mochilo.unpack(banana_pack_str, custom_type_config) -> Object
  *
  * Unpacks a BananaPack stream into a Ruby object.
  */
-static VALUE rb_mochilo_unpack(VALUE self, VALUE rb_buffer)
+static VALUE rb_mochilo_unpack(int argc, VALUE *argv, VALUE self)
 {
-	return rb_mochilo__unpack(rb_buffer);
+	VALUE rb_buffer, rb_opts;
+	rb_scan_args(argc, argv, "11", &rb_buffer, &rb_opts);
+	return rb_mochilo__unpack(rb_buffer, rb_opts);
 }
 
 /* Document-method: pack
@@ -88,7 +91,7 @@ static VALUE rb_mochilo_pack(int argc, VALUE *argv, VALUE self)
 void Init_mochilo()
 {
 	rb_mMochilo = rb_define_module("Mochilo");
-	rb_define_method(rb_mMochilo, "unpack", rb_mochilo_unpack, 1);
+	rb_define_method(rb_mMochilo, "unpack", rb_mochilo_unpack, -1);
 	rb_define_method(rb_mMochilo, "pack", rb_mochilo_pack, -1);
 
 	rb_eMochiloError = rb_define_class_under(rb_mMochilo, "Error", rb_eStandardError);

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -1,3 +1,4 @@
+extern ID s_call;
 
 MOAPI mo_value moapi_bytes_new(const char *src, size_t len)
 {
@@ -16,6 +17,17 @@ MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t enc
 	rb_enc_set_index(str, index);
 
 	return (mo_value)str;
+}
+
+MOAPI mo_value moapi_custom_new(const char *src, size_t len, VALUE rb_opts)
+{
+	VALUE decoder, result;
+	decoder = rb_hash_aref(rb_opts, INT2NUM(*src));
+	result = rb_str_new(src + 1, len - 1);
+	if (!NIL_P(decoder)) {
+		result = rb_funcall(decoder, s_call, 1, result);
+	}
+	return (mo_value)result;
 }
 
 MOAPI mo_value moapi_array_new(size_t array_size)

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -290,5 +290,6 @@ class MochiloPackTest < Minitest::Test
   def test_pack_symbol_with_custom_type_roundtrips
     packed = Mochilo.pack(:symbol, ::Symbol => [0x00, lambda { |sym| sym.to_s }])
     unpacked = Mochilo.unpack(packed, 0x00 => lambda { |raw| raw.to_sym })
+    assert_equal :symbol, unpacked
   end
 end

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -281,4 +281,14 @@ class MochiloPackTest < Minitest::Test
       Mochilo.pack(:symbol)
     end
   end
+
+  def test_pack_symbol_with_custom_type
+    expected = "\xC7\x07\xFF\x00symbol"
+    assert_equal expected, Mochilo.pack(:symbol, ::Symbol => [0x00, lambda { |sym| sym.to_s }])
+  end
+
+  def test_pack_symbol_with_custom_type_roundtrips
+    packed = Mochilo.pack(:symbol, ::Symbol => [0x00, lambda { |sym| sym.to_s }])
+    unpacked = Mochilo.unpack(packed, 0x00 => lambda { |raw| raw.to_sym })
+  end
 end


### PR DESCRIPTION
In https://github.com/github/bert/pull/12, I'd like to replace BERT's custom encoding with mochilo. However, BERT supports a couple of types that msgpack and mochilo don't support (`Symbol`, `Time`, `Regexp`). This branch lets me provide custom serialization for these types.

This branch adds an optional second argument to `pack` and `unpack`. The last argument to `pack` is a hash of custom classes to a type code and serialization proc. The last argument to `unpack` is a hash of type code to deserialization proc. They can be used like this:

```ruby
irb(main):001:0> str = Mochilo.pack([:sym], Symbol => [0x01, lambda { |sym| sym.to_s }])
=> "\x91\xC7\x04\xFF\x01sym"
irb(main):002:0> Mochilo.unpack(str, 0x01 => lambda { |raw| raw.to_sym })
=> [:sym]
```

To encode these custom types, I've added a new use for msgpack's extension type. Mochilo already uses the extension type for strings with encodings. With this branch, the custom serializers set the encoding id to `0xFF` (which isn't in a valid encoding id), the next byte is the type code, and the rest of the bytes are the result of the custom serializer.

cc @brianmario @vmg @kivikakk @carlosmn @piki