### PR TITLE
Add support for Symbol, Regexp, and Time

### DIFF
--- a/docs/format-spec.md
+++ b/docs/format-spec.md
@@ -39,3 +39,53 @@ For serializing text up to (2^32)-1 bytes.
 => ZZZZZZZZ_ZZZZZZZZ_ZZZZZZZZ_ZZZZZZZZ - a big-endian 32-bit unsigned integer which represents the legth of data.
 => type - encoding flag, a signed 8-bit signed integer
 ```
+
+#### Extensions
+
+If the encoding flag is `0xff`, the data is not a string. The first byte of the data field defines the type, and the rest of the data field is defined per type.
+The length of the enclosing ENCx type is the combined length of ext type and ext data.
+
+```
+----+-----------+----------+==========+
+... | type=0xff | ext type | ext data |
+----+-----------+----------+==========+
+```
+
+* Symbol, ext type = 0
+* Regexp, ext type = 1
+* Time, ext type = 2
+
+##### Symbol
+
+Symbols are encoded as the symbol's name, without a NUL terminator.
+
+```
+----+-----------+----------+=============+
+... | type=0xff |   0x00   | symbol name |
+----+-----------+----------+=============+
+```
+
+##### Regexp
+
+Regexps are encoded as 32-bit integer from ruby's `Regexp#options`, an 8-bit encoding type, and the text of the regexp.
+
+```
+----+-----------+----------+--------+--------+--------+--------+--------+======+
+... | type=0xff |   0x01   |XXXXXXXX|XXXXXXXX|XXXXXXXX|XXXXXXXX|YYYYYYYY| data |
+----+-----------+----------+--------+--------+--------+--------+--------+======+
+XXXXXXXX_XXXXXXXX_XXXXXXXX_XXXXXXXX 32-bit unsigned options
+YYYYYYYY encoding flag
+```
+
+##### Time
+
+Time values are encoded as a 64-bit unsigned number of seconds since the epoch, a 64-bit unsigned number of usec, and a 32-bit signed seconds of offset from UTC.
+
+```
+----+-----------+----------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+
+... | type=0xff |   0x02   |XXXXXXXX|XXXXXXXX|XXXXXXXX|XXXXXXXX|XXXXXXXX|XXXXXXXX|XXXXXXXX|XXXXXXXX|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|YYYYYYYY|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|ZZZZZZZZ|
+----+-----------+----------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+--------+
+XXXXXXXX... whole seconds since epoch
+YYYYYYYY... usec fraction to add to X
+ZZZZZZZZ... (signed) seconds offset from UTC
+```

--- a/ext/mochilo/mochilo.h
+++ b/ext/mochilo/mochilo.h
@@ -153,6 +153,7 @@ enum msgpack_err_t {
 enum mochilo_ext_types_t {
 	MOCHILO_T_SYMBOL,
 	MOCHILO_T_REGEXP,
+	MOCHILO_T_TIME,
 };
 
 typedef void * mo_value;

--- a/ext/mochilo/mochilo.h
+++ b/ext/mochilo/mochilo.h
@@ -149,6 +149,11 @@ enum msgpack_err_t {
 	MSGPACK_ENOTHING = -3,
 };
 
+#define MOCHILO_EXT_TYPE 0xff
+enum mochilo_ext_types_t {
+	MOCHILO_T_SYMBOL,
+};
+
 typedef void * mo_value;
 typedef uint64_t mo_integer;
 int mochilo_unpack_one(mo_value *_value, mochilo_src *src);

--- a/ext/mochilo/mochilo.h
+++ b/ext/mochilo/mochilo.h
@@ -152,6 +152,7 @@ enum msgpack_err_t {
 #define MOCHILO_EXT_TYPE 0xff
 enum mochilo_ext_types_t {
 	MOCHILO_T_SYMBOL,
+	MOCHILO_T_REGEXP,
 };
 
 typedef void * mo_value;

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -23,9 +23,11 @@ MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t 
 	return (mo_value)re;
 }
 
-MOAPI mo_value moapi_time_new(uint64_t sec, uint64_t usec)
+MOAPI mo_value moapi_time_new(uint64_t sec, uint64_t usec, int32_t utc_offset)
 {
-	return rb_time_new(sec, usec);
+	VALUE utc_time = rb_time_new(sec, usec);
+	return (mo_value)rb_funcall(utc_time,
+		rb_intern("getlocal"), 1, INT2FIX(utc_offset));
 }
 
 MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t encoding)

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -4,6 +4,17 @@ MOAPI mo_value moapi_bytes_new(const char *src, size_t len)
 	return (mo_value)rb_str_new(src, len);
 }
 
+MOAPI mo_value moapi_symbol_new(const char *src, size_t len)
+{
+	char *name = malloc(len + 1);
+	VALUE symbol;
+	strncpy(name, src, len);
+	name[len] = '\0';
+	symbol = ID2SYM(rb_intern(name));
+	free(name);
+	return symbol;
+}
+
 MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t encoding)
 {
 	int index = 0;

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -23,6 +23,11 @@ MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t 
 	return (mo_value)re;
 }
 
+MOAPI mo_value moapi_time_new(uint64_t sec, uint64_t usec)
+{
+	return rb_time_new(sec, usec);
+}
+
 MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t encoding)
 {
 	int index = 0;

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -15,6 +15,20 @@ MOAPI mo_value moapi_symbol_new(const char *src, size_t len)
 	return symbol;
 }
 
+MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t encoding, int reg_options)
+{
+	int index = 0;
+	VALUE re;
+
+	if (encoding < sizeof(mochilo_enc_lookup)/sizeof(mochilo_enc_lookup[0]))
+		index = rb_enc_find_index(mochilo_enc_lookup[encoding]);
+
+	re = rb_reg_new(src, len, reg_options);
+	rb_enc_set_index(re, index);
+
+	return (mo_value)re;
+}
+
 MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t encoding)
 {
 	int index = 0;

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -6,7 +6,7 @@ MOAPI mo_value moapi_bytes_new(const char *src, size_t len)
 
 MOAPI mo_value moapi_symbol_new(const char *src, size_t len)
 {
-	return ID2SYM(rb_intern(src));
+	return ID2SYM(rb_intern2(src, len));
 }
 
 MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t encoding, int reg_options)

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -6,13 +6,7 @@ MOAPI mo_value moapi_bytes_new(const char *src, size_t len)
 
 MOAPI mo_value moapi_symbol_new(const char *src, size_t len)
 {
-	char *name = malloc(len + 1);
-	VALUE symbol;
-	strncpy(name, src, len);
-	name[len] = '\0';
-	symbol = ID2SYM(rb_intern(name));
-	free(name);
-	return symbol;
+	return ID2SYM(rb_intern(src));
 }
 
 MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t encoding, int reg_options)

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -108,9 +108,8 @@ void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
 	symbol_name = rb_id2name(SYM2ID(rb_symbol));
 	size = strlen(symbol_name);
 
-	mochilo_put_ext_size_and_type(buf, size + 1, MOCHILO_T_SYMBOL);
+	mochilo_put_ext_size_and_type(buf, size, MOCHILO_T_SYMBOL);
 	mochilo_buf_put(buf, symbol_name, size);
-	mochilo_buf_putc(buf, '\0'); // null-terminate, to avoid an allocation on unpack
 }
 
 void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -136,7 +136,16 @@ void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)
 
 void mochilo_pack_time(mochilo_buf *buf, VALUE rb_time)
 {
-	rb_raise(rb_eMochiloPackError, "todo: time");
+	struct time_object *tobj;
+	uint64_t sec;
+	uint64_t usec;
+
+	sec = NUM2ULONG(rb_funcall(rb_time, rb_intern("to_i"), 0));
+	usec = NUM2ULONG(rb_funcall(rb_time, rb_intern("usec"), 0));
+
+	mochilo_put_ext_size_and_type(buf, 16, MOCHILO_T_TIME);
+	mochilo_buf_put64be(buf, &sec);
+	mochilo_buf_put64be(buf, &usec);
 }
 
 struct mochilo_hash_pack {

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -9,6 +9,26 @@ extern VALUE rb_eMochiloPackError;
 
 void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object);
 
+static void mochilo_buf_put_ext_size(mochilo_buf *buf, long size)
+{
+	if (size < 0x100) {
+		uint8_t lead = size;
+		mochilo_buf_putc(buf, MSGPACK_T_ENC8);
+		mochilo_buf_putc(buf, lead);
+	} else if (size < 0x10000) {
+		uint16_t lead = size;
+		mochilo_buf_putc(buf, MSGPACK_T_ENC16);
+		mochilo_buf_put16be(buf, &lead);
+	} else if (size < 0x100000000) {
+		mochilo_buf_putc(buf, MSGPACK_T_ENC32);
+		mochilo_buf_put32be(buf, &size);
+	} else {
+		// there is no ext 64
+		rb_raise(rb_eMochiloPackError,
+			"String cannot be larger than %ld bytes", 0x100000000);
+	}
+}
+
 void mochilo_pack_fixnum(mochilo_buf *buf, VALUE rb_fixnum)
 {
 	long fixnum = NUM2LONG(rb_fixnum);
@@ -75,7 +95,16 @@ void mochilo_pack_bignum(mochilo_buf *buf, VALUE rb_bignum)
 
 void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
 {
-	rb_raise(rb_eMochiloPackError, "todo: symbol");
+	char *symbol_name;
+	size_t size;
+
+	symbol_name = rb_id2name(SYM2ID(rb_symbol));
+	size = strlen(symbol_name);
+
+	mochilo_buf_put_ext_size(buf, size + 1);
+	mochilo_buf_putc(buf, MOCHILO_EXT_TYPE);
+	mochilo_buf_putc(buf, MOCHILO_T_SYMBOL);
+	mochilo_buf_put(buf, symbol_name, size);
 }
 
 void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)
@@ -191,23 +220,7 @@ void mochilo_pack_str(mochilo_buf *buf, VALUE rb_str)
 		}
 	} else {
 		// if another encoding is used we need to use our custom types
-		if (size < 0x100) {
-			uint8_t lead = size;
-			mochilo_buf_putc(buf, MSGPACK_T_ENC8);
-			mochilo_buf_putc(buf, lead);
-		} else if (size < 0x10000) {
-			uint16_t lead = size;
-			mochilo_buf_putc(buf, MSGPACK_T_ENC16);
-			mochilo_buf_put16be(buf, &lead);
-		} else if (size < 0x100000000) {
-			mochilo_buf_putc(buf, MSGPACK_T_ENC32);
-			mochilo_buf_put32be(buf, &size);
-		} else {
-			// there is no ext 64
-			rb_raise(rb_eMochiloPackError,
-				"String cannot be larger than %ld bytes", 0x100000000);
-		}
-
+		mochilo_buf_put_ext_size(buf, size);
 		enc2id = mochilo_encoding_to_id(enc_name, (unsigned int)strlen(enc_name));
 		mochilo_buf_putc(buf, enc2id ? enc2id->id : 0);
 	}

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -138,13 +138,16 @@ void mochilo_pack_time(mochilo_buf *buf, VALUE rb_time)
 	struct time_object *tobj;
 	uint64_t sec;
 	uint64_t usec;
+	int32_t utc_offset;
 
 	sec = NUM2ULONG(rb_funcall(rb_time, rb_intern("to_i"), 0));
 	usec = NUM2ULONG(rb_funcall(rb_time, rb_intern("usec"), 0));
+	utc_offset = NUM2INT(rb_funcall(rb_time, rb_intern("utc_offset"), 0));
 
-	mochilo_put_ext_size_and_type(buf, 16, MOCHILO_T_TIME);
+	mochilo_put_ext_size_and_type(buf, 8+8+4, MOCHILO_T_TIME);
 	mochilo_buf_put64be(buf, &sec);
 	mochilo_buf_put64be(buf, &usec);
+	mochilo_buf_put32be(buf, &utc_offset);
 }
 
 struct mochilo_hash_pack {

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -108,8 +108,9 @@ void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
 	symbol_name = rb_id2name(SYM2ID(rb_symbol));
 	size = strlen(symbol_name);
 
-	mochilo_put_ext_size_and_type(buf, size, MOCHILO_T_SYMBOL);
+	mochilo_put_ext_size_and_type(buf, size + 1, MOCHILO_T_SYMBOL);
 	mochilo_buf_put(buf, symbol_name, size);
+	mochilo_buf_putc(buf, '\0'); // null-terminate, to avoid an allocation on unpack
 }
 
 void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -93,6 +93,13 @@ void mochilo_pack_bignum(mochilo_buf *buf, VALUE rb_bignum)
 	}
 }
 
+static void mochilo_put_ext_size_and_type(mochilo_buf *buf, size_t size, enum mochilo_ext_types_t type)
+{
+	mochilo_buf_put_ext_size(buf, size + 1);
+	mochilo_buf_putc(buf, MOCHILO_EXT_TYPE);
+	mochilo_buf_putc(buf, type);
+}
+
 void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
 {
 	char *symbol_name;
@@ -101,9 +108,7 @@ void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
 	symbol_name = rb_id2name(SYM2ID(rb_symbol));
 	size = strlen(symbol_name);
 
-	mochilo_buf_put_ext_size(buf, size + 1);
-	mochilo_buf_putc(buf, MOCHILO_EXT_TYPE);
-	mochilo_buf_putc(buf, MOCHILO_T_SYMBOL);
+	mochilo_put_ext_size_and_type(buf, size, MOCHILO_T_SYMBOL);
 	mochilo_buf_put(buf, symbol_name, size);
 }
 

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -73,6 +73,21 @@ void mochilo_pack_bignum(mochilo_buf *buf, VALUE rb_bignum)
 	}
 }
 
+void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
+{
+	rb_raise(rb_eMochiloPackError, "todo: symbol");
+}
+
+void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)
+{
+	rb_raise(rb_eMochiloPackError, "todo: regexp");
+}
+
+void mochilo_pack_time(mochilo_buf *buf, VALUE rb_time)
+{
+	rb_raise(rb_eMochiloPackError, "todo: time");
+}
+
 struct mochilo_hash_pack {
 	mochilo_buf *buf;
 };
@@ -267,9 +282,21 @@ void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object)
 		mochilo_pack_bignum(buf, rb_object);
 		return;
 
+	case T_SYMBOL:
+		mochilo_pack_symbol(buf, rb_object);
+		return;
+
+	case T_REGEXP:
+		mochilo_pack_regexp(buf, rb_object);
+		return;
+
 	default:
-		rb_raise(rb_eMochiloPackError,
+		if (rb_cTime == rb_obj_class(rb_object)) {
+			mochilo_pack_time(buf, rb_object);
+		} else {
+			rb_raise(rb_eMochiloPackError,
 				"Unsupported object type: %s", rb_obj_classname(rb_object));
+		}
 		return;
 	}
 }

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -114,7 +114,23 @@ void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
 
 void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)
 {
-	rb_raise(rb_eMochiloPackError, "todo: regexp");
+	uint32_t options;
+	size_t size;
+	rb_encoding *encoding;
+	char *enc_name;
+	const struct mochilo_enc_map *enc2id;
+
+	encoding = rb_enc_get(rb_regexp);
+	enc_name = rb_enc_name(encoding);
+	enc2id = mochilo_encoding_to_id(enc_name, (unsigned int)strlen(enc_name));
+
+	options = rb_reg_options(rb_regexp);
+	size = RREGEXP_SRC_LEN(rb_regexp);
+
+	mochilo_put_ext_size_and_type(buf, 4 + 1 + size, MOCHILO_T_REGEXP);
+	mochilo_buf_put32be(buf, &options);
+	mochilo_buf_putc(buf, enc2id ? enc2id->id : 0);
+	mochilo_buf_put(buf, RREGEXP_SRC_PTR(rb_regexp), size);
 }
 
 void mochilo_pack_time(mochilo_buf *buf, VALUE rb_time)

--- a/ext/mochilo/mochilo_unpack.c
+++ b/ext/mochilo/mochilo_unpack.c
@@ -103,14 +103,16 @@ static int mochilo_unpack_custom(mo_value *_value, mochilo_src *src, size_t leng
 		{
 			uint64_t sec;
 			uint64_t usec;
+			int32_t utc_offset;
 
-			if (length != 16)
+			if (length != 8+8+4)
 				return -1;
 
 			mochilo_src_get64be(src, &sec);
 			mochilo_src_get64be(src, &usec);
+			mochilo_src_get32be(src, &utc_offset);
 
-			*_value = moapi_time_new(sec, usec);
+			*_value = moapi_time_new(sec, usec, utc_offset);
 			return 0;
 		}
 

--- a/ext/mochilo/mochilo_unpack.c
+++ b/ext/mochilo/mochilo_unpack.c
@@ -76,8 +76,6 @@ static int mochilo_unpack_custom(mo_value *_value, mochilo_src *src, size_t leng
 			const char *ptr;
 			if (!(ptr = mochilo_src_peek(src, length)))
 				return -1;
-			if (ptr[length-1] != '\0')
-				return -1;
 			*_value = moapi_symbol_new(ptr, length);
 			return 0;
 		}

--- a/ext/mochilo/mochilo_unpack.c
+++ b/ext/mochilo/mochilo_unpack.c
@@ -6,6 +6,8 @@
 #include "mochilo.h"
 #include "mochilo_api.h"
 
+extern VALUE rb_eMochiloUnpackError;
+
 static inline int unpack_array(mo_value *_array, size_t elements, mochilo_src *buf)
 {
 	size_t i;
@@ -57,7 +59,6 @@ static inline int unpack_hash(mo_value *_hash, size_t elements, mochilo_src *buf
 	return 0; \
 }
 
-extern VALUE rb_eMochiloPackError;
 static int mochilo_unpack_custom(mo_value *_value, mochilo_src *src, size_t length)
 {
 	uint8_t custom_type;
@@ -116,6 +117,7 @@ static int mochilo_unpack_custom(mo_value *_value, mochilo_src *src, size_t leng
 		}
 
 		default:
+			rb_raise(rb_eMochiloUnpackError, "unknown custom type 0x%02x", custom_type);
 			return -1;
 	}
 }

--- a/ext/mochilo/mochilo_unpack.c
+++ b/ext/mochilo/mochilo_unpack.c
@@ -75,6 +75,8 @@ static int mochilo_unpack_custom(mo_value *_value, mochilo_src *src, size_t leng
 			const char *ptr;
 			if (!(ptr = mochilo_src_peek(src, length)))
 				return -1;
+			if (ptr[length-1] != '\0')
+				return -1;
 			*_value = moapi_symbol_new(ptr, length);
 			return 0;
 		}

--- a/ext/mochilo/mochilo_unpack.c
+++ b/ext/mochilo/mochilo_unpack.c
@@ -100,8 +100,22 @@ static int mochilo_unpack_custom(mo_value *_value, mochilo_src *src, size_t leng
 			return 0;
 		}
 
+		case MOCHILO_T_TIME:
+		{
+			uint64_t sec;
+			uint64_t usec;
+
+			if (length != 16)
+				return -1;
+
+			mochilo_src_get64be(src, &sec);
+			mochilo_src_get64be(src, &usec);
+
+			*_value = moapi_time_new(sec, usec);
+			return 0;
+		}
+
 		default:
-			rb_raise(rb_eMochiloPackError, "unrecognized custom type 0x%02x\n", custom_type);
 			return -1;
 	}
 }

--- a/ext/mochilo/mochilo_unpack.c
+++ b/ext/mochilo/mochilo_unpack.c
@@ -57,6 +57,21 @@ static inline int unpack_hash(mo_value *_hash, size_t elements, mochilo_src *buf
 	return 0; \
 }
 
+extern VALUE rb_eMochiloPackError;
+static int mochilo_unpack_custom(mo_value *_value, const char *encoded, size_t length)
+{
+	char custom_type = *encoded++;
+	switch (custom_type) {
+		case MOCHILO_T_SYMBOL:
+			*_value = moapi_symbol_new(encoded, length);
+			return 0;
+
+		default:
+			rb_raise(rb_eMochiloPackError, "unrecognized custom type %d\n", custom_type);
+			return -1;
+	}
+}
+
 int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 {
 	uint8_t leader;
@@ -217,6 +232,9 @@ int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 			if (!(ptr = mochilo_src_peek(src, length)))
 				return -1;
 
+			if (encoding == MOCHILO_EXT_TYPE)
+				return mochilo_unpack_custom(_value, ptr, length);
+
 			*_value = moapi_str_new(ptr, length, encoding);
 			return 0;
 		}
@@ -234,6 +252,9 @@ int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 			if (!(ptr = mochilo_src_peek(src, length)))
 				return -1;
 
+			if (encoding == MOCHILO_EXT_TYPE)
+				return mochilo_unpack_custom(_value, ptr, length);
+
 			*_value = moapi_str_new(ptr, length, encoding);
 			return 0;
 		}
@@ -250,6 +271,9 @@ int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 
 			if (!(ptr = mochilo_src_peek(src, length)))
 				return -1;
+
+			if (encoding == MOCHILO_EXT_TYPE)
+				return mochilo_unpack_custom(_value, ptr, length);
 
 			*_value = moapi_str_new(ptr, length, encoding);
 			return 0;

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -277,7 +277,7 @@ class MochiloPackTest < Minitest::Test
   end
 
   def test_pack_symbol
-    expected = "\xC7\x08\xFF\x00symbol\x00"
+    expected = "\xC7\x07\xFF\x00symbol"
     assert_equal expected, Mochilo.pack(:symbol)
     assert_equal :symbol, Mochilo.unpack(expected)
   end

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -294,11 +294,14 @@ class MochiloPackTest < Minitest::Test
   end
 
   def test_time
-    t = Time.gm(2042, 7, 21, 3, 32, 37, 974010)
-    expected = "\xC7\x11\xFF\x02" +
+    offset = -13*60*60 # I don't know if this is possible. There shouldn't be anything with a greater absolute value.
+    t = Time.gm(2042, 7, 21, 3, 32, 37, 974010).getlocal(offset)
+    expected = "\xC7\x15\xFF\x02" +
       "\x00\x00\x00\x00\x88\x77\x66\x55" + # sec
-      "\x00\x00\x00\x00\x00\x0E\xDC\xBA"   # usec
+      "\x00\x00\x00\x00\x00\x0E\xDC\xBA" + # usec
+      "\xFF\xFF\x49\x30"                   # utc_offset
     assert_equal expected, Mochilo.pack(t)
     assert_equal t, Mochilo.unpack(expected)
+    assert_equal offset, Mochilo.unpack(expected).utc_offset
   end
 end

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -294,8 +294,10 @@ class MochiloPackTest < Minitest::Test
   end
 
   def test_time
-    t = Time.at(1234567890.22)
-    expected = "\xC7\x07\xFF\x02nfi"
+    t = Time.gm(2042, 7, 21, 3, 32, 37, 974010)
+    expected = "\xC7\x11\xFF\x02" +
+      "\x00\x00\x00\x00\x88\x77\x66\x55" + # sec
+      "\x00\x00\x00\x00\x00\x0E\xDC\xBA"   # usec
     assert_equal expected, Mochilo.pack(t)
     assert_equal t, Mochilo.unpack(expected)
   end

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -276,9 +276,27 @@ class MochiloPackTest < Minitest::Test
     end
   end
 
-  def test_pack_symbol_fails
-    assert_raises Mochilo::PackError do
-      Mochilo.pack(:symbol)
+  def test_pack_symbol
+    expected = "\xC7\x07\xFF\x00symbol"
+    assert_equal expected, Mochilo.pack(:symbol)
+    assert_equal :symbol, Mochilo.unpack(expected)
+  end
+
+  def test_pack_regexp
+    expected = "\xC7\x07\xFF\x01\x00pa.tern"
+    assert_equal expected, Mochilo.pack(/pa.tern/)
+    [
+      /pa.tern/,
+      /thing/im,
+    ].each do |re|
+      assert_equal re, Mochilo.unpack(Mochilo.pack(re))
     end
+  end
+
+  def test_time
+    t = Time.at(1234567890.22)
+    expected = "\xC7\x07\xFF\x02nfi"
+    assert_equal expected, Mochilo.pack(t)
+    assert_equal t, Mochilo.unpack(expected)
   end
 end

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -277,7 +277,7 @@ class MochiloPackTest < Minitest::Test
   end
 
   def test_pack_symbol
-    expected = "\xC7\x07\xFF\x00symbol"
+    expected = "\xC7\x08\xFF\x00symbol\x00"
     assert_equal expected, Mochilo.pack(:symbol)
     assert_equal :symbol, Mochilo.unpack(expected)
   end

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -283,7 +283,7 @@ class MochiloPackTest < Minitest::Test
   end
 
   def test_pack_regexp
-    expected = "\xC7\x07\xFF\x01\x00pa.tern"
+    expected = "\xC7\x0D\xFF\x01\x00\x00\x00\x00\x01pa.tern"
     assert_equal expected, Mochilo.pack(/pa.tern/)
     [
       /pa.tern/,

--- a/test/unpack_test.rb
+++ b/test/unpack_test.rb
@@ -328,7 +328,7 @@ class MochiloUnpackTest < Minitest::Test
     # time overflows
     assert_raises RangeError do
       # set the top bit of the time.....v ...and of usec................v
-      Mochilo.unpack("\xC7\x11\xFF\x02\x80\x00\x00\x00\x88\x77\x66\x55\x80\x00\x00\x00\x00\x0E\xDC\xBA")
+      Mochilo.unpack("\xC7\x15\xFF\x02\x80\x00\x00\x00\x88\x77\x66\x55\x80\x00\x00\x00\x00\x0E\xDC\xBA\xFF\xFF\xFF\xFF")
     end
 
     # unknown field
@@ -342,7 +342,7 @@ class MochiloUnpackTest < Minitest::Test
   def test_unpack_custom_types_with_missing_char
     assert_error_on_truncated_unpack "\xC7\x07\xFF\x00symbol"
     assert_error_on_truncated_unpack "\xC7\x0D\xFF\x01\x00\x00\x00\x00\x01pa.tern"
-    assert_error_on_truncated_unpack "\xC7\x11\xFF\x02\x00\x00\x00\x00\x88\x77\x66\x55\x00\x00\x00\x00\x00\x0E\xDC\xBA"
+    assert_error_on_truncated_unpack "\xC7\x15\xFF\x02\x00\x00\x00\x00\x88\x77\x66\x55\x00\x00\x00\x00\x00\x0E\xDC\xBA\x00\x00\x00\x00"
   end
 
   def assert_error_on_truncated_unpack(packed)


### PR DESCRIPTION
I'd like to use mochilo for the next version of [BERT](https://github.com/github/bert)'s encoding. BERT needs to be able to serialize Symbol, Regexp, and Time values, in addition to the types that Mochilo already supports. This branch adds support for these three types.

cc @brianmario @vmg @kivikakk @carlosmn @piki
alternative to #18