### PR TITLE
Add a way to generate packed data the same way that v1.2 did

### DIFF
--- a/ext/mochilo/mochilo.h
+++ b/ext/mochilo/mochilo.h
@@ -148,6 +148,11 @@ enum msgpack_err_t {
 	MSGPACK_EUNSAFE = -4,
 };
 
+typedef enum mochilo_pack_opts_t {
+	MOCHILO_PACK_TRUSTED = 1<<0,
+	MOCHILO_PACK_V_1_3 = 1<<1,
+} mochilo_pack_opts_t;
+
 typedef void * mo_value;
 typedef uint64_t mo_integer;
 int mochilo_unpack_one(mo_value *_value, mochilo_src *src);

--- a/ext/mochilo/mochilo.h
+++ b/ext/mochilo/mochilo.h
@@ -152,9 +152,7 @@ typedef void * mo_value;
 typedef uint64_t mo_integer;
 int mochilo_unpack_one(mo_value *_value, mochilo_src *src);
 
-#ifdef HAVE_RUBY_ENCODING_H
-#	include <ruby/encoding.h>
-#	include "encodings.h"
-#endif
+#include <ruby/encoding.h>
+#include "encodings.h"
 
 #endif

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -18,7 +18,6 @@ MOAPI mo_value moapi_sym_new(const char *src, size_t len)
 	return (mo_value)ID2SYM(rb_intern(symbol));
 }
 
-#ifdef HAVE_RUBY_ENCODING_H
 MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t encoding, int reg_options)
 {
 	int index = 0;
@@ -32,7 +31,6 @@ MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t 
 
 	return (mo_value)re;
 }
-#endif
 
 MOAPI mo_value moapi_time_new(uint64_t sec, uint64_t usec, int32_t utc_offset)
 {
@@ -41,7 +39,6 @@ MOAPI mo_value moapi_time_new(uint64_t sec, uint64_t usec, int32_t utc_offset)
 		rb_intern("getlocal"), 1, INT2FIX(utc_offset));
 }
 
-#ifdef HAVE_RUBY_ENCODING_H
 MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t encoding)
 {
 	int index = 0;
@@ -55,7 +52,6 @@ MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t enc
 
 	return (mo_value)str;
 }
-#endif
 
 MOAPI mo_value moapi_array_new(size_t array_size)
 {

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -7,7 +7,7 @@
 
 extern VALUE rb_eMochiloPackError;
 
-void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, int trusted);
+void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, mochilo_pack_opts_t opts);
 
 void mochilo_pack_fixnum(mochilo_buf *buf, VALUE rb_fixnum)
 {
@@ -123,14 +123,14 @@ void mochilo_pack_time(mochilo_buf *buf, VALUE rb_time)
 
 struct mochilo_hash_pack {
 	mochilo_buf *buf;
-	int trusted;
+	mochilo_pack_opts_t opts;
 };
 
 static int hash_callback(VALUE key, VALUE val, VALUE opaque)
 {
 	struct mochilo_hash_pack *hash_pack = (struct mochilo_hash_pack*)opaque;
-	mochilo_pack_one(hash_pack->buf, key, hash_pack->trusted);
-	mochilo_pack_one(hash_pack->buf, val, hash_pack->trusted);
+	mochilo_pack_one(hash_pack->buf, key, hash_pack->opts);
+	mochilo_pack_one(hash_pack->buf, val, hash_pack->opts);
 	return 0;
 }
 
@@ -141,13 +141,13 @@ void mochilo_pack_double(mochilo_buf *buf, VALUE rb_double)
 	mochilo_buf_put64be(buf, &d);
 }
 
-void mochilo_pack_hash(mochilo_buf *buf, VALUE rb_hash, int trusted)
+void mochilo_pack_hash(mochilo_buf *buf, VALUE rb_hash, mochilo_pack_opts_t opts)
 {
 	struct mochilo_hash_pack hash_pack;
 	long size = RHASH_SIZE(rb_hash);
 
 	hash_pack.buf = buf;
-	hash_pack.trusted = trusted;
+	hash_pack.opts = opts;
 
 	if (size < 0x10) {
 		uint8_t lead = 0x80 | size;
@@ -238,7 +238,7 @@ void mochilo_pack_str(mochilo_buf *buf, VALUE rb_str)
 	mochilo_buf_put(buf, RSTRING_PTR(rb_str), size);
 }
 
-void mochilo_pack_array(mochilo_buf *buf, VALUE rb_array, int trusted)
+void mochilo_pack_array(mochilo_buf *buf, VALUE rb_array, mochilo_pack_opts_t opts)
 {
 	long i, size = RARRAY_LEN(rb_array);
 
@@ -259,13 +259,17 @@ void mochilo_pack_array(mochilo_buf *buf, VALUE rb_array, int trusted)
 	}
 
 	for (i = 0; i < size; i++) {
-		mochilo_pack_one(buf, rb_ary_entry(rb_array, i), trusted);
+		mochilo_pack_one(buf, rb_ary_entry(rb_array, i), opts);
 	}
 }
 
-void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, int trusted)
+void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, mochilo_pack_opts_t opts)
 {
-	switch (rb_type(rb_object)) {
+	int trusted = opts & MOCHILO_PACK_TRUSTED;
+	int v13types = opts & MOCHILO_PACK_V_1_3;
+	int rb_obj_type = rb_type(rb_object);
+
+	switch (rb_obj_type) {
 	case T_NIL:
 		mochilo_buf_putc(buf, MSGPACK_T_NIL);
 		return;
@@ -312,12 +316,10 @@ void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, int trusted)
 		mochilo_pack_bignum(buf, rb_object);
 		return;
 
-	case T_REGEXP:
-		mochilo_pack_regexp(buf, rb_object);
-		return;
-
 	default:
-		if (rb_cTime == rb_obj_class(rb_object)) {
+		if (v13types && rb_obj_type == T_REGEXP) {
+			mochilo_pack_regexp(buf, rb_object);
+		} else if (v13types && rb_cTime == rb_obj_class(rb_object)) {
 			mochilo_pack_time(buf, rb_object);
 		} else if (rb_respond_to(rb_object, rb_intern("to_bpack"))) {
 			VALUE bpack = rb_funcall(rb_object, rb_intern("to_bpack"), 0);

--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -73,7 +73,6 @@ void mochilo_pack_bignum(mochilo_buf *buf, VALUE rb_bignum)
 	}
 }
 
-#ifdef HAVE_RUBY_ENCODING_H
 void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)
 {
 	size_t size;
@@ -105,7 +104,6 @@ void mochilo_pack_regexp(mochilo_buf *buf, VALUE rb_regexp)
 			"Regexp too long: must be under %d bytes, %ld given", 1<<16, size);
 	}
 }
-#endif
 
 void mochilo_pack_time(mochilo_buf *buf, VALUE rb_time)
 {
@@ -213,7 +211,6 @@ void mochilo_pack_symbol(mochilo_buf *buf, VALUE rb_symbol)
 	mochilo_buf_put(buf, name, size);
 }
 
-#ifdef HAVE_RUBY_ENCODING_H
 void mochilo_pack_str(mochilo_buf *buf, VALUE rb_str)
 {
 	long size = RSTRING_LEN(rb_str);
@@ -240,7 +237,6 @@ void mochilo_pack_str(mochilo_buf *buf, VALUE rb_str)
 	mochilo_buf_putc(buf, enc2id ? enc2id->id : 0);
 	mochilo_buf_put(buf, RSTRING_PTR(rb_str), size);
 }
-#endif
 
 void mochilo_pack_array(mochilo_buf *buf, VALUE rb_array, int trusted)
 {
@@ -294,11 +290,9 @@ void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, int trusted)
 		return;
 
 	case T_STRING:
-#ifdef HAVE_RUBY_ENCODING_H
 		if (ENCODING_GET(rb_object) != 0)
 			mochilo_pack_str(buf, rb_object);
 		else
-#endif
 			mochilo_pack_bytes(buf, rb_object);
 		return;
 
@@ -318,11 +312,9 @@ void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, int trusted)
 		mochilo_pack_bignum(buf, rb_object);
 		return;
 
-#ifdef HAVE_RUBY_ENCODING_H
 	case T_REGEXP:
 		mochilo_pack_regexp(buf, rb_object);
 		return;
-#endif
 
 	default:
 		if (rb_cTime == rb_obj_class(rb_object)) {

--- a/ext/mochilo/mochilo_unpack.c
+++ b/ext/mochilo/mochilo_unpack.c
@@ -178,7 +178,6 @@ int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 			return 0;
 		}
 
-#ifdef HAVE_RUBY_ENCODING_H
 		case MSGPACK_T_REGEXP:
 		{
 			uint16_t length;
@@ -197,7 +196,6 @@ int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 			*_value = moapi_regexp_new(ptr, length, encoding, options);
 			return 0;
 		}
-#endif
 
 		case MSGPACK_T_TIME:
 		{
@@ -214,7 +212,6 @@ int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 			return 0;
 		}
 
-#ifdef HAVE_RUBY_ENCODING_H
 		case MSGPACK_T_STR16:
 		{
 			uint16_t length;
@@ -248,7 +245,6 @@ int mochilo_unpack_one(mo_value *_value, mochilo_src *src)
 			*_value = moapi_str_new(ptr, length, encoding);
 			return 0;
 		}
-#endif
 
 		case MSGPACK_T_RAW16:
 		{

--- a/lib/mochilo.rb
+++ b/lib/mochilo.rb
@@ -8,4 +8,14 @@ module Mochilo
   alias load unpack
 
   extend self
+
+  module Compat_1_2
+    alias encode pack
+    alias dump pack
+
+    alias decode unpack
+    alias load unpack
+
+    extend self
+  end
 end

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -199,4 +199,16 @@ class MochiloPackTest < MiniTest::Unit::TestCase
     assert_equal t, unpacked
     assert_equal t.utc_offset, unpacked.utc_offset
   end
+
+  def test_pack_1_2_time
+    assert_raises Mochilo::PackError do
+      Mochilo::Compat_1_2.pack(Time.now)
+    end
+  end
+
+  def test_pack_1_2_regexp
+    assert_raises Mochilo::PackError do
+      Mochilo::Compat_1_2.pack(/hi/)
+    end
+  end
 end

--- a/test/unpack_test.rb
+++ b/test/unpack_test.rb
@@ -156,4 +156,18 @@ class MochiloUnpackTest < MiniTest::Unit::TestCase
   def test_unpack_map32
     # TODO: not sure how to test this without making a massive 66k item hash
   end
+
+  def test_unpack_time_compat
+    t = Time.at 1234567890
+    packed = Mochilo.pack(t)
+    assert_equal t, Mochilo.unpack(packed)
+    assert_equal t, Mochilo::Compat_1_2.unpack(packed)
+  end
+
+  def test_unpack_regex_compat
+    re = /hi/i
+    packed = Mochilo.pack(re)
+    assert_equal re, Mochilo.unpack(packed)
+    assert_equal re, Mochilo::Compat_1_2.unpack(packed)
+  end
 end


### PR DESCRIPTION
This branch adds a `Mochilo::Compat_1_2` module. The new module has the same API as `Mochilo` (pack, unpack, etc). The new module can unpack anything from v1.2 or v1.3. It packs like v1.2 did. This will allow running applications to install v1.3 and drop in `Mochilo::Compat_1_2` in place of `Mochilo`. Once all consumers (code that runs `unpack`) has been upgraded to v1.3, the app can switch back to using `Mochilo`.

cc @brianmario @vmg