### PR TITLE
Propagate all encoding opts to hash and array

### DIFF
--- a/ext/mochilo/mochilo_pack.c
+++ b/ext/mochilo/mochilo_pack.c
@@ -301,11 +301,11 @@ void mochilo_pack_one(mochilo_buf *buf, VALUE rb_object, mochilo_pack_opts_t opt
 		return;
 
 	case T_HASH:
-		mochilo_pack_hash(buf, rb_object, trusted);
+		mochilo_pack_hash(buf, rb_object, opts);
 		return;
 
 	case T_ARRAY:
-		mochilo_pack_array(buf, rb_object, trusted);
+		mochilo_pack_array(buf, rb_object, opts);
 		return;
 
 	case T_FLOAT:

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -200,6 +200,12 @@ class MochiloPackTest < MiniTest::Unit::TestCase
     assert_equal t.utc_offset, unpacked.utc_offset
   end
 
+  def test_nested
+    re = /anything/
+    t = Time.gm(1234567890)
+    assert_equal [{t => re}], Mochilo.unpack(Mochilo.pack([{t => re}]))
+  end
+
   def test_pack_1_2_time
     assert_raises Mochilo::PackError do
       Mochilo::Compat_1_2.pack(Time.now)


### PR DESCRIPTION
#21 introduced a bug related to encoding Regexp and Time objects. I added a new flag to the C code that indicates whether the types are supported, and forgot to add the flag to recursive calls to encode Array and Hash objects. So, in v1.3.0, mochilo is able to encode a Time object anywhere that it sees it in the payload, but in v1.3.1 mochilo can only encode Time objects that are the top-level object that's encoded. For example, it's unable to encode an Array that contains a Time object.

This branch fixes encoding nested Time and Regexp objects, and adds a regression test.

cc @brianmario 