### PR TITLE
Update supported ruby types in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ The following Ruby types are supported. Meaning they will be deserialized into t
 
 If any other object type is encountered during serialization, an exception is raised. This is to ensure you have explicit control over what is being serialized.
 
-* Fixnum
+* Array
 * Bignum
+* Fixnum
 * Float
+* Hash
+* Regexp
 * String (with encoding)
 * Symbol
+* Time
 * nil
 * true
 * false
-* Array
-* Hash
-* Regexp
-* Time

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ If any other object type is encountered during serialization, an exception is ra
 * Bignum
 * Float
 * String (with encoding)
+* Symbol
 * nil
 * true
 * false
@@ -42,5 +43,3 @@ If any other object type is encountered during serialization, an exception is ra
 * Hash
 * Regexp
 * Time
-
-*note:* Symbol is supported as well, but is unpacked as String

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ If any other object type is encountered during serialization, an exception is ra
 * false
 * Array
 * Hash
+* Regexp
+* Time
+
+*note:* Symbol is supported as well, but is unpacked as String


### PR DESCRIPTION
According to https://github.com/brianmario/mochilo/blob/master/docs/format-spec.md#extensions it looks like Symbol, RegExp and Time are supported out of the box now?

The readme doesn't list them as supported types.