### PR TITLE
Stop checking encoding names

### DIFF
--- a/genperf.rb
+++ b/genperf.rb
@@ -8,7 +8,7 @@ struct mochilo_enc_map { const char *name; uint8_t id; }
 %%
 header
 
-encodings = Encoding.list.reject {|e| e.name == 'ASCII-8BIT'}
+encodings = Encoding.list.reject {|e| e == Encoding::BINARY }
 encodings.each do |encoding|
   puts "#{encoding.name}, MSGPACK_ENC_#{encoding.name.gsub('-', '_').upcase}"
 end


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576