### PR TITLE
Fix crash on Ruby 3.2 due to string encodings 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,21 @@
 PATH
   remote: .
   specs:
-    mochilo (1.2.1)
+    mochilo (1.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.0.9)
-    method_source (0.8.1)
-    minitest (5.0.6)
-    msgpack (0.5.5)
-    pry (0.9.12.2)
-      coderay (~> 1.0.5)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-    rake (10.1.0)
-    rake-compiler (0.8.3)
+    coderay (1.1.3)
+    method_source (1.0.0)
+    minitest (5.19.0)
+    msgpack (1.7.2)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.0.6)
+    rake-compiler (1.2.5)
       rake
-    slop (3.4.5)
 
 PLATFORMS
   ruby
@@ -28,3 +26,6 @@ DEPENDENCIES
   msgpack
   pry
   rake-compiler (>= 0.8.1)
+
+BUNDLED WITH
+   2.4.15

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rake/clean'
 require 'rake/extensiontask'
 require 'digest/md5'
 
-task :default => :compile
+task :default => :test
 
 # ==========================================================
 # Ruby Extension
@@ -17,16 +17,14 @@ end
 
 desc "Open an irb session preloaded with Mochilo"
 task :console do
-  sh "irb -rubygems -I lib -r ./lib/mochilo"
+  sh "irb -I lib -r ./lib/mochilo"
 end
 
 require 'rake/testtask'
 Rake::TestTask.new('test') do |t|
   t.test_files = FileList['test/*_test.rb']
-  t.ruby_opts += ['-rubygems'] if defined? Gem
 end
 task 'test' => [:compile]
-
 
 task :encodings do
   sh "ruby genperf.rb | gperf > ./ext/mochilo/encodings.h"

--- a/ext/mochilo/mochilo_api.h
+++ b/ext/mochilo/mochilo_api.h
@@ -20,14 +20,15 @@ MOAPI mo_value moapi_sym_new(const char *src, size_t len)
 
 MOAPI mo_value moapi_regexp_new(const char *src, size_t len, enum msgpack_enc_t encoding, int reg_options)
 {
-	int index = 0;
+	rb_encoding *rbencoding = NULL;
 	VALUE re;
 
 	if (encoding < sizeof(mochilo_enc_lookup)/sizeof(mochilo_enc_lookup[0]))
-		index = rb_enc_find_index(mochilo_enc_lookup[encoding]);
+		rbencoding = rb_enc_find(mochilo_enc_lookup[encoding]);
+	else
+		rbencoding = rb_ascii8bit_encoding();
 
-	re = rb_reg_new(src, len, reg_options);
-	rb_enc_set_index(re, index);
+	re = rb_enc_reg_new(src, len, rbencoding, reg_options);
 
 	return (mo_value)re;
 }
@@ -41,14 +42,15 @@ MOAPI mo_value moapi_time_new(uint64_t sec, uint64_t usec, int32_t utc_offset)
 
 MOAPI mo_value moapi_str_new(const char *src, size_t len, enum msgpack_enc_t encoding)
 {
-	int index = 0;
+	rb_encoding *rbencoding = NULL;
 	VALUE str;
 
 	if (encoding < sizeof(mochilo_enc_lookup)/sizeof(mochilo_enc_lookup[0]))
-		index = rb_enc_find_index(mochilo_enc_lookup[encoding]);
+		rbencoding = rb_enc_find(mochilo_enc_lookup[encoding]);
+	else
+		rbencoding = rb_ascii8bit_encoding();
 
-	str = rb_str_new(src, len);
-	rb_enc_set_index(str, index);
+	str = rb_enc_str_new(src, len, rbencoding);
 
 	return (mo_value)str;
 }

--- a/mochilo.gemspec
+++ b/mochilo.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.4.2}
   s.summary = %q{A ruby library for BananaPack}
   s.test_files = `git ls-files test`.split("\n")
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.4.0"
 
   # tests
   s.add_development_dependency 'rake-compiler', ">= 0.8.1"

--- a/test/pack_test.rb
+++ b/test/pack_test.rb
@@ -4,7 +4,7 @@ require File.expand_path('../setup', __FILE__)
 require 'mochilo'
 require 'stringio'
 
-class MochiloPackTest < MiniTest::Unit::TestCase
+class MochiloPackTest < Minitest::Test
 
   OBJECTS = [
     {"hello" => "world"},

--- a/test/unpack_test.rb
+++ b/test/unpack_test.rb
@@ -174,4 +174,19 @@ class MochiloUnpackTest < Minitest::Test
     assert_equal re, Mochilo.unpack(packed)
     assert_equal re, Mochilo::Compat_1_2.unpack(packed)
   end
+
+  def test_unpack_multibyte_strings_of_various_sizes
+    # Check a variety of sizes
+    0.upto(2000) do |size|
+      contents = "a"*size
+      contents.force_encoding("UTF-16BE")
+      packed = Mochilo.pack(contents)
+      unpacked = Mochilo.unpack(packed)
+
+      # Regression test: previously crashed on Ruby 3.2
+      unpacked.b
+
+      assert_equal contents, unpacked
+    end
+  end
 end

--- a/test/unpack_test.rb
+++ b/test/unpack_test.rb
@@ -31,12 +31,16 @@ class MochiloUnpackTest < Minitest::Test
       a = Mochilo.unpack(buf)
       b = Mochilo.pack(a)
       c = Mochilo.unpack(b)
-      assert_equal a, c
+      if a.nil?
+        assert_nil c
+      else
+        assert_equal a, c
+      end
     end
   end
 
   def test_unpack_nil
-    assert_equal nil, Mochilo.unpack("\xC0")
+    assert_nil Mochilo.unpack("\xC0")
   end
 
   def test_unpack_true
@@ -61,7 +65,7 @@ class MochiloUnpackTest < Minitest::Test
   end
 
   def test_unpack_negative_fixed
-    assert_equal -21, Mochilo.unpack("\xEB")
+    assert_equal(-21, Mochilo.unpack("\xEB"))
   end
 
   def test_unpack_uint8
@@ -81,19 +85,19 @@ class MochiloUnpackTest < Minitest::Test
   end
 
   def test_unpack_int8
-    assert_equal -34, Mochilo.unpack("\xD0\xDE")
+    assert_equal(-34, Mochilo.unpack("\xD0\xDE"))
   end
 
   def test_unpack_int16
-    assert_equal -21474, Mochilo.unpack("\xD1\xAC\x1E")
+    assert_equal(-21474, Mochilo.unpack("\xD1\xAC\x1E"))
   end
 
   def test_unpack_int32
-    assert_equal -2147483647, Mochilo.unpack("\xD2\x80\x00\x00\x01")
+    assert_equal(-2147483647, Mochilo.unpack("\xD2\x80\x00\x00\x01"))
   end
 
   def test_unpack_int64
-    assert_equal -21474836479, Mochilo.unpack("\xD3\xFF\xFF\xFF\xFB\x00\x00\x00\x01")
+    assert_equal(-21474836479, Mochilo.unpack("\xD3\xFF\xFF\xFF\xFB\x00\x00\x00\x01"))
   end
 
   if defined?(Encoding)

--- a/test/unpack_test.rb
+++ b/test/unpack_test.rb
@@ -3,7 +3,7 @@ require File.expand_path('../setup', __FILE__)
 
 require 'mochilo'
 
-class MochiloUnpackTest < MiniTest::Unit::TestCase
+class MochiloUnpackTest < Minitest::Test
   BUFFERS = [
     "\xCC\x80",
     "\xCD\x04\xD2",


### PR DESCRIPTION
`rb_enc_set_index` only changes the encoding flag of the object it does not fix up the terminator of the passed object. This means that any encoding which uses multiple bytes for its terminator may end up with an invalid string. `rb_enc_associate_index` should be used instead.

However on modern Rubies it's faster and simpler to use the `rb_enc_str_new` (2.4+) or `rb_enc_reg_new` (1.9+) APIs.

(I send this PR against v1-release, as that has the most recent commits, unsure if that's right)